### PR TITLE
fix(#4): 検索機能をページ内パネルに一本化

### DIFF
--- a/content.css
+++ b/content.css
@@ -178,10 +178,12 @@
 
 .gcl-item-actions {
   display: none;
+  flex-wrap: wrap;
   gap: 6px;
   margin-top: 6px;
 }
 .gcl-item:hover .gcl-item-actions { display: flex; }
+.gcl-actions-break { width: 100%; margin: 0; }
 .gcl-item-actions button {
   font-size: 11px;
   padding: 3px 10px;
@@ -190,10 +192,23 @@
   cursor: pointer;
   background: none;
 }
+.gcl-btn-show { color: #5f6368; border-color: #dadce0; }
+.gcl-btn-show:hover { background: #f1f3f4; }
+.gcl-btn-goto { color: #188038; border-color: #188038; }
+.gcl-btn-goto:hover { background: #e6f4ea; }
+.gcl-btn-open { color: #188038; border-color: #188038; }
+.gcl-btn-open:hover { background: #e6f4ea; }
 .gcl-btn-dl  { color: #7986cb; border-color: #7986cb; }
 .gcl-btn-dl:hover  { background: #f3eeff; }
 .gcl-btn-del { color: #c5221f; border-color: #c5221f; }
 .gcl-btn-del:hover { background: #fce8e6; }
+
+.gcl-item-actions.gcl-confirming { display: flex; align-items: center; }
+.gcl-confirm-label { font-size: 11px; color: #c5221f; margin-right: 4px; }
+.gcl-btn-ok  { color: #c5221f; border-color: #c5221f; }
+.gcl-btn-ok:hover  { background: #fce8e6; }
+.gcl-btn-cancel { color: #5f6368; border-color: #dadce0; }
+.gcl-btn-cancel:hover { background: #f1f3f4; }
 
 /* 詳細ビュー */
 #gcl-detail {

--- a/content.css
+++ b/content.css
@@ -176,6 +176,25 @@
   color: #888;
 }
 
+.gcl-item-actions {
+  display: none;
+  gap: 6px;
+  margin-top: 6px;
+}
+.gcl-item:hover .gcl-item-actions { display: flex; }
+.gcl-item-actions button {
+  font-size: 11px;
+  padding: 3px 10px;
+  border-radius: 12px;
+  border: 1px solid;
+  cursor: pointer;
+  background: none;
+}
+.gcl-btn-dl  { color: #7986cb; border-color: #7986cb; }
+.gcl-btn-dl:hover  { background: #f3eeff; }
+.gcl-btn-del { color: #c5221f; border-color: #c5221f; }
+.gcl-btn-del:hover { background: #fce8e6; }
+
 /* 詳細ビュー */
 #gcl-detail {
   overflow-y: auto;

--- a/content.js
+++ b/content.js
@@ -411,7 +411,11 @@ function renderPanel(logs, q) {
       <div class="gcl-item-meta">${dateStr} · ${log.turns.length}ターン</div>
       ${snippet ? `<div class="gcl-item-snippet">${highlight(snippet, q)}</div>` : ''}
       <div class="gcl-item-actions">
-        <button class="gcl-btn-dl" data-id="${escHtml(log.id)}">⬇ 再DL</button>
+        <button class="gcl-btn-show" data-id="${escHtml(log.id)}">表示</button>
+        <button class="gcl-btn-goto" data-url="${escHtml(log.url)}">このチャットへ</button>
+        <button class="gcl-btn-open" data-url="${escHtml(log.url)}">(新タブ)このチャットへ</button>
+        <div class="gcl-actions-break"></div>
+        <button class="gcl-btn-dl" data-id="${escHtml(log.id)}">⬇ DL</button>
         <button class="gcl-btn-del" data-id="${escHtml(log.id)}">🗑 削除</button>
       </div>
     </div>`;
@@ -421,6 +425,27 @@ function renderPanel(logs, q) {
     el.addEventListener('click', e => {
       if (e.target.closest('.gcl-item-actions')) return;
       openDetail(el.dataset.id, logs, q);
+    });
+  });
+
+  list.querySelectorAll('.gcl-btn-show').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      openDetail(btn.dataset.id, logs, q);
+    });
+  });
+
+  list.querySelectorAll('.gcl-btn-goto').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      location.href = btn.dataset.url;
+    });
+  });
+
+  list.querySelectorAll('.gcl-btn-open').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      window.open(btn.dataset.url, '_blank');
     });
   });
 
@@ -438,8 +463,29 @@ function renderPanel(logs, q) {
     btn.addEventListener('click', e => {
       e.stopPropagation();
       const id = btn.dataset.id;
-      chrome.storage.local.get({ logs: [] }, data => {
-        chrome.storage.local.set({ logs: data.logs.filter(l => l.id !== id) });
+      const actions = btn.closest('.gcl-item-actions');
+      if (actions.classList.contains('gcl-confirming')) return;
+
+      actions.classList.add('gcl-confirming');
+      actions.innerHTML = `
+        <span class="gcl-confirm-label">削除しますか？</span>
+        <button class="gcl-btn-cancel">キャンセル</button>
+        <button class="gcl-btn-ok" data-id="${id}">OK</button>
+      `;
+
+      actions.querySelector('.gcl-btn-ok').addEventListener('click', e => {
+        e.stopPropagation();
+        const okBtn = e.currentTarget;
+        if (okBtn.disabled) return;
+        okBtn.disabled = true;
+        chrome.storage.local.get({ logs: [] }, data => {
+          chrome.storage.local.set({ logs: data.logs.filter(l => l.id !== id) });
+        });
+      });
+
+      actions.querySelector('.gcl-btn-cancel').addEventListener('click', e => {
+        e.stopPropagation();
+        renderPanel(logs, q);
       });
     });
   });

--- a/content.js
+++ b/content.js
@@ -4,7 +4,7 @@ const BUTTON_ID      = 'gemini-logger-btn';
 const ZIP_BUTTON_ID  = 'gemini-logger-zip-btn';
 const SEARCH_BTN_ID  = 'gemini-logger-search-btn';
 const PANEL_ID       = 'gemini-logger-panel';
-const VERSION        = 'v2.3';
+const VERSION        = 'v2.4';
 
 // ── Shift-JISエンコーダ ───────────────────────────────────────────────────
 // TextDecoder('shift-jis')を逆引きして変換マップを構築する。
@@ -405,16 +405,43 @@ function renderPanel(logs, q) {
   list.innerHTML = filtered.map(log => {
     const snippet = getSnippet(log, q);
     const d = new Date(log.date);
-    const dateStr = d.toLocaleString('ja-JP', { month:'2-digit', day:'2-digit', hour:'2-digit', minute:'2-digit' });
+    const dateStr = d.toLocaleString('ja-JP', { year: '2-digit', month:'2-digit', day:'2-digit', hour:'2-digit', minute:'2-digit' });
     return `<div class="gcl-item" data-id="${escHtml(log.id)}">
       <div class="gcl-item-title">${highlight(log.title, q)}</div>
       <div class="gcl-item-meta">${dateStr} · ${log.turns.length}ターン</div>
       ${snippet ? `<div class="gcl-item-snippet">${highlight(snippet, q)}</div>` : ''}
+      <div class="gcl-item-actions">
+        <button class="gcl-btn-dl" data-id="${escHtml(log.id)}">⬇ 再DL</button>
+        <button class="gcl-btn-del" data-id="${escHtml(log.id)}">🗑 削除</button>
+      </div>
     </div>`;
   }).join('');
 
   list.querySelectorAll('.gcl-item').forEach(el => {
-    el.addEventListener('click', () => openDetail(el.dataset.id, logs, q));
+    el.addEventListener('click', e => {
+      if (e.target.closest('.gcl-item-actions')) return;
+      openDetail(el.dataset.id, logs, q);
+    });
+  });
+
+  list.querySelectorAll('.gcl-btn-dl').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const log = logs.find(l => l.id === btn.dataset.id);
+      if (!log) return;
+      const text = formatAsText(log.turns, log.url, log.date);
+      sendDownloadText(text, `gemini_${toDatetimeStr(log.date)}_${safeFilename(log.title)}.txt`);
+    });
+  });
+
+  list.querySelectorAll('.gcl-btn-del').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const id = btn.dataset.id;
+      chrome.storage.local.get({ logs: [] }, data => {
+        chrome.storage.local.set({ logs: data.logs.filter(l => l.id !== id) });
+      });
+    });
   });
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gemini Chat Logger",
-  "version": "2.3",
+  "version": "2.4",
   "description": "Geminiの会話ログをダウンロード・全文検索",
   "permissions": ["storage", "downloads"],
   "host_permissions": ["https://gemini.google.com/*"],

--- a/popup.html
+++ b/popup.html
@@ -43,27 +43,6 @@
       border-radius: 12px;
     }
 
-    .search-area {
-      padding: 10px 12px;
-      background: white;
-      border-bottom: 1px solid #e0e0e0;
-      flex-shrink: 0;
-    }
-
-    .search-area input {
-      width: 100%;
-      padding: 8px 12px;
-      border: 1.5px solid #dadce0;
-      border-radius: 20px;
-      font-size: 13px;
-      outline: none;
-      transition: border-color 0.2s;
-    }
-
-    .search-area input:focus {
-      border-color: #1a73e8;
-    }
-
     .toolbar {
       padding: 6px 12px;
       background: white;
@@ -290,10 +269,6 @@
     <h1>Gemini Chat Logger</h1>
     <span class="count" id="total-count">0件</span>
   </header>
-
-  <div class="search-area">
-    <input type="text" id="search-input" placeholder="会話を全文検索..." autocomplete="off">
-  </div>
 
   <div class="toolbar">
     <span class="result-info" id="result-info"></span>

--- a/popup.js
+++ b/popup.js
@@ -52,7 +52,7 @@ function renderList() {
         </div>
         ${snippet ? `<div class="snippet">${escapeHtml(snippet)}</div>` : ''}
         <div class="actions">
-          <button class="btn-dl" data-id="${escapeHtml(log.id)}">⬇ 再ダウンロード</button>
+          <button class="btn-dl" data-id="${escapeHtml(log.id)}">⬇ DL</button>
           <button class="btn-del" data-id="${escapeHtml(log.id)}">🗑 削除</button>
         </div>
       </div>

--- a/popup.js
+++ b/popup.js
@@ -1,15 +1,6 @@
-// ポップアップの検索・表示ロジック
+// ポップアップの表示ロジック
 
 let allLogs = [];
-let currentQuery = '';
-
-// ハイライト用: クエリにマッチした部分をmarkタグで囲む
-function highlight(text, query) {
-  if (!query) return escapeHtml(text);
-  const escaped = escapeHtml(text);
-  const escapedQuery = escapeHtml(query).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return escaped.replace(new RegExp(escapedQuery, 'gi'), m => `<mark>${m}</mark>`);
-}
 
 function escapeHtml(str) {
   return str
@@ -19,35 +10,9 @@ function escapeHtml(str) {
     .replace(/"/g, '&quot;');
 }
 
-// 検索: タイトル・全ターンのテキストを対象
-function filterLogs(logs, query) {
-  if (!query.trim()) return logs;
-  const q = query.toLowerCase();
-  return logs.filter(log => {
-    if (log.title.toLowerCase().includes(q)) return true;
-    return log.turns.some(t => t.content.toLowerCase().includes(q));
-  });
-}
-
-// マッチしたスニペットを抽出
-function getSnippet(log, query) {
-  if (!query.trim()) {
-    const first = log.turns.find(t => t.role === 'model');
-    return first ? first.content.slice(0, 80) + '...' : '';
-  }
-  const q = query.toLowerCase();
-  for (const turn of log.turns) {
-    const idx = turn.content.toLowerCase().indexOf(q);
-    if (idx !== -1) {
-      const start = Math.max(0, idx - 30);
-      const end = Math.min(turn.content.length, idx + query.length + 60);
-      let snippet = turn.content.slice(start, end);
-      if (start > 0) snippet = '...' + snippet;
-      if (end < turn.content.length) snippet += '...';
-      return snippet;
-    }
-  }
-  return '';
+function getSnippet(log) {
+  const first = log.turns.find(t => t.role === 'model');
+  return first ? first.content.slice(0, 80) + (first.content.length > 80 ? '...' : '') : '';
 }
 
 function formatDate(isoStr) {
@@ -59,41 +24,33 @@ function formatDate(isoStr) {
 }
 
 function renderList() {
-  const filtered = filterLogs(allLogs, currentQuery);
   const listEl = document.getElementById('log-list');
   const resultInfo = document.getElementById('result-info');
 
   document.getElementById('total-count').textContent = `${allLogs.length}件`;
+  resultInfo.textContent = `保存済み: ${allLogs.length}件`;
 
-  if (currentQuery) {
-    resultInfo.textContent = `"${currentQuery}" — ${filtered.length}件ヒット`;
-  } else {
-    resultInfo.textContent = `保存済み: ${allLogs.length}件`;
-  }
-
-  if (filtered.length === 0) {
+  if (allLogs.length === 0) {
     listEl.innerHTML = `
       <div class="empty">
-        <div class="icon">${currentQuery ? '🔍' : '📭'}</div>
-        <div>${currentQuery ? '一致する会話が見つかりません' : 'まだ会話が保存されていません'}</div>
-        ${!currentQuery ? '<div style="font-size:12px;margin-top:6px">Geminiのページで「💾 ログを保存」ボタンをクリックしてください</div>' : ''}
+        <div class="icon">📭</div>
+        <div>まだ会話が保存されていません</div>
+        <div style="font-size:12px;margin-top:6px">Geminiのページで「💾 ログを保存」ボタンをクリックしてください</div>
       </div>
     `;
     return;
   }
 
-  listEl.innerHTML = filtered.map(log => {
-    const snippet = getSnippet(log, currentQuery);
-    const highlightedTitle = highlight(log.title, currentQuery);
-    const highlightedSnippet = snippet ? highlight(snippet, currentQuery) : '';
+  listEl.innerHTML = allLogs.map(log => {
+    const snippet = getSnippet(log);
     return `
       <div class="log-item" data-id="${escapeHtml(log.id)}">
-        <div class="title">${highlightedTitle}</div>
+        <div class="title">${escapeHtml(log.title)}</div>
         <div class="meta">
           <span>${formatDate(log.date)}</span>
           <span>${log.turns.length}ターン</span>
         </div>
-        ${highlightedSnippet ? `<div class="snippet">${highlightedSnippet}</div>` : ''}
+        ${snippet ? `<div class="snippet">${escapeHtml(snippet)}</div>` : ''}
         <div class="actions">
           <button class="btn-dl" data-id="${escapeHtml(log.id)}">⬇ 再ダウンロード</button>
           <button class="btn-del" data-id="${escapeHtml(log.id)}">🗑 削除</button>
@@ -135,7 +92,7 @@ function openDetail(id) {
   body.innerHTML = log.turns.map(turn => `
     <div class="turn ${turn.role}">
       <div class="role">${turn.role === 'user' ? 'ユーザー' : 'Gemini'}</div>
-      <div class="content">${highlight(turn.content, currentQuery)}</div>
+      <div class="content">${escapeHtml(turn.content)}</div>
     </div>
   `).join('');
 
@@ -192,12 +149,6 @@ function clearAll() {
 // 初期化
 chrome.storage.local.get({ logs: [] }, data => {
   allLogs = data.logs;
-  renderList();
-});
-
-// 検索入力
-document.getElementById('search-input').addEventListener('input', e => {
-  currentQuery = e.target.value;
   renderList();
 });
 


### PR DESCRIPTION
## 変更内容

### ページ内パネル（content.js / content.css）
- 個別削除ボタンを追加（インライン確認UI付き）
- DL・表示・このチャットへ・(新タブ)このチャットへ ボタンを追加
- ボタンを2段レイアウトで表示
- ログ一覧の日付に年を追加（#2 同時対応）

### ポップアップ（popup.html / popup.js）
- 検索入力・フィルタリングを削除してシンプルなログ一覧ビューに変更
- 検索機能はページ内パネルに一本化

## 既知の不具合（別イシューで対応予定）
- #15: 削除後に自動保存でログが復活する
- #16: ZIPが.txtでDLされる

## クローズ
Closes #4
Closes #9