### PR TITLE
fix(#1,#20): 検索パネルの重なり解消・ボタン半透明化 (v2.7)

### DIFF
--- a/content.css
+++ b/content.css
@@ -16,8 +16,9 @@
   align-items: center;
   white-space: nowrap;
   overflow: hidden;
-  transition: padding 0.2s ease, background 0.2s, transform 0.1s, box-shadow 0.2s;
+  transition: padding 0.2s ease, background 0.2s, transform 0.1s, box-shadow 0.2s, opacity 0.2s;
   user-select: none;
+  opacity: 0.85;
 }
 
 #gemini-logger-search-btn { top: 120px; background: #7986cb; }
@@ -40,9 +41,9 @@
   margin-left: 6px;
 }
 
-#gemini-logger-search-btn:hover { background: #5c6bc0; box-shadow: 0 3px 10px rgba(0,0,0,0.35); }
-#gemini-logger-btn:hover        { background: #1557b0; box-shadow: 0 3px 10px rgba(0,0,0,0.35); }
-#gemini-logger-zip-btn:hover    { background: #0d652d; box-shadow: 0 3px 10px rgba(0,0,0,0.35); }
+#gemini-logger-search-btn:hover { background: #5c6bc0; box-shadow: 0 3px 10px rgba(0,0,0,0.35); opacity: 1; }
+#gemini-logger-btn:hover        { background: #1557b0; box-shadow: 0 3px 10px rgba(0,0,0,0.35); opacity: 1; }
+#gemini-logger-zip-btn:hover    { background: #0d652d; box-shadow: 0 3px 10px rgba(0,0,0,0.35); opacity: 1; }
 
 #gemini-logger-search-btn:active,
 #gemini-logger-btn:active,
@@ -71,7 +72,7 @@
 #gemini-logger-panel {
   position: fixed;
   top: 80px;
-  right: 110px;
+  right: 135px;
   width: 360px;
   max-height: 80vh;
   z-index: 99998;

--- a/content.js
+++ b/content.js
@@ -4,7 +4,7 @@ const BUTTON_ID      = 'gemini-logger-btn';
 const ZIP_BUTTON_ID  = 'gemini-logger-zip-btn';
 const SEARCH_BTN_ID  = 'gemini-logger-search-btn';
 const PANEL_ID       = 'gemini-logger-panel';
-const VERSION        = 'v2.6';
+const VERSION        = 'v2.7';
 
 // ── Shift-JISエンコーダ ───────────────────────────────────────────────────
 // TextDecoder('shift-jis')を逆引きして変換マップを構築する。

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gemini Chat Logger",
-  "version": "2.6",
+  "version": "2.7",
   "description": "Geminiの会話ログをダウンロード・全文検索",
   "permissions": ["storage", "downloads"],
   "host_permissions": ["https://gemini.google.com/*"],


### PR DESCRIPTION
## Summary
- fix(#1): 検索パネルの `right` を `110px` → `135px` に調整し、フローティングボタンとの重なりを解消
- fix(#20): フローティングボタンを非ホバー時 `opacity: 0.85`、ホバー時 `opacity: 1` に設定し視覚的主張を軽減

## Test plan
- [x] 検索パネルを開いたとき、フローティングボタンと重ならないことを確認
- [x] フローティングボタンが非ホバー時に半透明（0.85）で表示されることを確認
- [x] フローティングボタンがホバー時に完全不透明（1.0）になることを確認
- [x] 保存・ZIP・検索の各ボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)