### PR TITLE
fix(#15): 表示中スレッド削除後にトップへ遷移し自動保存復活を防止 (v2.8)

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,7 +4,7 @@ const BUTTON_ID      = 'gemini-logger-btn';
 const ZIP_BUTTON_ID  = 'gemini-logger-zip-btn';
 const SEARCH_BTN_ID  = 'gemini-logger-search-btn';
 const PANEL_ID       = 'gemini-logger-panel';
-const VERSION        = 'v2.7';
+const VERSION        = 'v2.8';
 
 // ── Shift-JISエンコーダ ───────────────────────────────────────────────────
 // TextDecoder('shift-jis')を逆引きして変換マップを構築する。
@@ -479,7 +479,11 @@ function renderPanel(logs, q) {
         if (okBtn.disabled) return;
         okBtn.disabled = true;
         chrome.storage.local.get({ logs: [] }, data => {
+          const target = data.logs.find(l => l.id === id);
           chrome.storage.local.set({ logs: data.logs.filter(l => l.id !== id) });
+          if (target && target.url === location.href) {
+            location.href = 'https://gemini.google.com/';
+          }
         });
       });
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gemini Chat Logger",
-  "version": "2.7",
+  "version": "2.8",
   "description": "Geminiの会話ログをダウンロード・全文検索",
   "permissions": ["storage", "downloads"],
   "host_permissions": ["https://gemini.google.com/*"],


### PR DESCRIPTION
## Summary
- 削除対象ログのURLが現在のページと一致する場合、削除後に `https://gemini.google.com/` へ遷移
- URLが一致しない場合は従来通りパネル内で削除のみ
- フラグ制御不要のシンプルな実装

## Test plan
- [x] 表示中のスレッドのログを削除したとき、トップページへ遷移することを確認
- [x] 遷移後、削除したログが自動保存で復活しないことを確認
- [x] 別スレッドのログを削除したとき、パネル内で消えるだけで遷移しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)