### PR TITLE
fix: 保存ボタンのエラーメッセージを「ログがありません」に統一 (#21)

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,7 +4,7 @@ const BUTTON_ID      = 'gemini-logger-btn';
 const ZIP_BUTTON_ID  = 'gemini-logger-zip-btn';
 const SEARCH_BTN_ID  = 'gemini-logger-search-btn';
 const PANEL_ID       = 'gemini-logger-panel';
-const VERSION        = 'v2.9T1';
+const VERSION        = 'v2.9';
 
 // ── Shift-JISエンコーダ ───────────────────────────────────────────────────
 // TextDecoder('shift-jis')を逆引きして変換マップを構築する。

--- a/content.js
+++ b/content.js
@@ -4,7 +4,7 @@ const BUTTON_ID      = 'gemini-logger-btn';
 const ZIP_BUTTON_ID  = 'gemini-logger-zip-btn';
 const SEARCH_BTN_ID  = 'gemini-logger-search-btn';
 const PANEL_ID       = 'gemini-logger-panel';
-const VERSION        = 'v2.8';
+const VERSION        = 'v2.9T1';
 
 // ── Shift-JISエンコーダ ───────────────────────────────────────────────────
 // TextDecoder('shift-jis')を逆引きして変換マップを構築する。
@@ -291,7 +291,7 @@ function handleSaveClick() {
 
   const turns = scrapeConversation();
   if (!turns.length) {
-    setLabel(btn, '❌', '見つかりません');
+    setLabel(btn, '❌', 'ログがありません');
     btn.classList.add('error');
     setTimeout(() => { btn.disabled = false; setLabel(btn, '💾➜📄', 'ログを保存'); btn.classList.remove('error'); }, 2000);
     return;


### PR DESCRIPTION
## 概要

- 保存ボタン押下時のログ未保存エラーメッセージを `❌ 見つかりません` → `❌ ログがありません` に変更し、ZIPボタンのメッセージと統一

## 変更ファイル

- `content.js` — 7行目 VERSION を `v2.9T1`（動作確認用）、294行目 エラーメッセージ修正

## Test plan

- [x] ログが空の状態で💾➜📄ボタンを押し、`❌ ログがありません` と表示されることを確認
- [x] ログが空の状態で💾➜📦ボタンを押し、同じく `ログがありません` と表示されることを確認
- [x] 通常の保存・ZIP操作が引き続き正常に動作することを確認

Closes #21