### PR TITLE
fix: 手動保存でmergeWithExistingを使うよう修正 (#30)

### DIFF
--- a/content.js
+++ b/content.js
@@ -4,7 +4,7 @@ const BUTTON_ID      = 'gemini-logger-btn';
 const ZIP_BUTTON_ID  = 'gemini-logger-zip-btn';
 const SEARCH_BTN_ID  = 'gemini-logger-search-btn';
 const PANEL_ID       = 'gemini-logger-panel';
-const VERSION        = 'v3.1';
+const VERSION        = 'v3.3T1';
 
 // ── Shift-JISエンコーダ ───────────────────────────────────────────────────
 // TextDecoder('shift-jis')を逆引きして変換マップを構築する。

--- a/content.js
+++ b/content.js
@@ -295,18 +295,22 @@ function handleSaveClick() {
     return;
   }
 
-  const entry = makeEntry(turns, location.href);
   chrome.storage.local.get({ logs: [] }, data => {
-    const logs = [entry, ...data.logs.filter(l => l.url !== location.href)].slice(0, 200);
-    chrome.storage.local.set({ logs });
+    const logs     = data.logs;
+    const existing = logs.find(l => l.url === location.href);
+    const merged   = mergeWithExisting(existing?.turns, turns);
+    const entry    = makeEntry(merged, location.href);
+    if (existing) entry.id = existing.id;
+    const updated  = [entry, ...logs.filter(l => l.url !== location.href)].slice(0, 200);
+    chrome.storage.local.set({ logs: updated });
+
+    const text = formatAsText(entry.turns, entry.url, entry.date);
+    sendDownloadText(text, `gemini_${toDatetimeStr(entry.date)}_${safeFilename(entry.title)}.txt`);
+
+    setLabel(btn, '✅', chrome.i18n.getMessage('state_saved', [String(merged.length)]));
+    btn.classList.add('success');
+    setTimeout(() => { btn.disabled = false; setLabel(btn, '💾➜📄', chrome.i18n.getMessage('btn_save')); btn.classList.remove('success'); }, 2000);
   });
-
-  const text = formatAsText(entry.turns, entry.url, entry.date);
-  sendDownloadText(text, `gemini_${toDatetimeStr(entry.date)}_${safeFilename(entry.title)}.txt`);
-
-  setLabel(btn, '✅', chrome.i18n.getMessage('state_saved', [String(turns.length)]));
-  btn.classList.add('success');
-  setTimeout(() => { btn.disabled = false; setLabel(btn, '💾➜📄', chrome.i18n.getMessage('btn_save')); btn.classList.remove('success'); }, 2000);
 }
 
 // ── 📦 全ログをZIP（ストレージの全ログをまとめる） ────────────────────────

--- a/content.js
+++ b/content.js
@@ -4,7 +4,7 @@ const BUTTON_ID      = 'gemini-logger-btn';
 const ZIP_BUTTON_ID  = 'gemini-logger-zip-btn';
 const SEARCH_BTN_ID  = 'gemini-logger-search-btn';
 const PANEL_ID       = 'gemini-logger-panel';
-const VERSION        = 'v3.3T1';
+const VERSION        = 'v3.3';
 
 // ── Shift-JISエンコーダ ───────────────────────────────────────────────────
 // TextDecoder('shift-jis')を逆引きして変換マップを構築する。

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gemini Chat Logger",
-  "version": "3.3T1",
+  "version": "3.3",
   "default_locale": "en",
   "description": "__MSG_ext_description__",
   "permissions": ["storage", "downloads"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gemini Chat Logger",
-  "version": "3.3",
+  "version": "3.3T1",
   "default_locale": "en",
   "description": "__MSG_ext_description__",
   "permissions": ["storage", "downloads"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Gemini Chat Logger",
-  "version": "3.2",
+  "version": "3.3",
   "default_locale": "en",
   "description": "__MSG_ext_description__",
   "permissions": ["storage", "downloads"],


### PR DESCRIPTION
## 概要

手動保存（💾➜📄）でも `mergeWithExisting()` を使ってマージするよう修正。

**修正前:** スクレイプした `turns` をそのまま保存 → 仮想化で見えない古いターンが消える  
**修正後:** `autoSave` と同様に既存ターンとマージしてから保存

あわせて `existing.id` の引き継ぎも追加し、詳細ビューの参照が壊れないようにした。

## Test plan

- [x] 長いチャット（ターン仮想化が起きる状態）で手動保存し、古いターンが残ることを確認
- [x] 新規チャットで手動保存が正常に動作することを確認
- [x] ダウンロードされるテキストファイルに全ターンが含まれることを確認

Closes #30